### PR TITLE
Swap coverage widget to grab badges from s3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 .idea
 npm-debug.log*
 */badges.html
+*/badges.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,72 +1,7 @@
-# Compiled source #
-###################
-*.com
-*.class
-*.dll
-*.exe
-*.o
-*.so
-_site/
-
-# Packages #
-############
-# it's better to unpack these files and commit the raw source
-# git has its own built in compression methods
-*.7z
-*.dmg
-*.gz
-*.iso
-*.jar
-*.rar
-*.tar
-*.zip
-
-# Logs and databases #
-######################
-*.log
-*.sql
-*.sqlite
-
-# OS generated files #
-######################
 .DS_Store
-.DS_Store?
-.Spotlight-V100
-.Trashes
-Icon?
-ehthumbs.db
-Thumbs.db
-
-# Vim swap files #
-##################
-*.swp
-
-# Python #
-#################
-*.pyc
-*.egg-info/
-__pycache__/
-*.py[cod]
+node_modules
+build
 .env
-
-# Django #
-#################
-*.egg-info
-.installed.cfg
-
-# Unit test / coverage reports
-#################
-htmlcov/
-.tox/
-.coverage
-.cache
-nosetests.xml
-coverage.xml
-
-# Front-End #
-#############
-node_modules/
-bower_components/
-.grunt/
-src/vendor/
-build/
+.idea
+npm-debug.log*
+*/badges.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,74 @@
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+_site/
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# OS generated files #
+######################
 .DS_Store
-node_modules
-build
+.DS_Store?
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db
+
+# Vim swap files #
+##################
+*.swp
+
+# Python #
+#################
+*.pyc
+*.egg-info/
+__pycache__/
+*.py[cod]
 .env
-.idea
-npm-debug.log*
 */badges.html
 */badges.json
+
+# Django #
+#################
+*.egg-info
+.installed.cfg
+
+# Unit test / coverage reports
+#################
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Front-End #
+#############
+node_modules/
+bower_components/
+.grunt/
+src/vendor/
+build/

--- a/config.js
+++ b/config.js
@@ -19,11 +19,14 @@ var config = {
 
     // clients configs
     api: {
-        jenkins: {
-            baseUrl: process.env.MOZAIK_JENKINS_URL,
-            basicAuthUser: process.env.MOZAIK_JENKINS_USER,
-            basicAuthPassword: process.env.MOZAIK_JENKINS_PASSWORD
-        }
+        // aws: {
+        //     region: 'eu-west-1'
+        // },
+        // jenkins: {
+        //     baseUrl: process.env.MOZAIK_JENKINS_URL,
+        //     basicAuthUser: process.env.MOZAIK_JENKINS_USER,
+        //     basicAuthPassword: process.env.MOZAIK_JENKINS_PASSWORD
+        // }
     },
 
     // define duration between each dashboard rotation (ms)
@@ -41,16 +44,9 @@ var config = {
             rows:    6,
             widgets: [
                 {
-                    type: 'value.value',
-                    title: 'CF.gov JS Code Coverage',
-                    url: 'https://coveralls.io/github/cfpb/cfgov-refresh.json',
-                    pathCurrent: '$.coverage_change',
-                    pathLastUpdated: '$.created_at',
-                    // pathChangeRate: '$.changeRate',
-                    // lastUpdatedFormat: 'YYYY-MM-DDThh:mm:ssTZD',
-                    lastUpdatedFromNow: true,
-                    // prefix: '',
-                    postfix: '%',
+                    type: 'embed.markup',
+                    title: 'CF.gov Code Coverage',
+                    content: '<iframe width="100%" height="100%" src="http://files.consumerfinance.gov.s3.amazonaws.com/build/badges/badges.html" frameborder="0" allowfullscreen style="padding:1em 1em 4em" scrolling="no"></iframe>',
                     columns: 1, rows: 2,
                     x: 3, y: 4
                 },

--- a/config.js
+++ b/config.js
@@ -19,14 +19,11 @@ var config = {
 
     // clients configs
     api: {
-        // aws: {
-        //     region: 'eu-west-1'
-        // },
-        // jenkins: {
-        //     baseUrl: process.env.MOZAIK_JENKINS_URL,
-        //     basicAuthUser: process.env.MOZAIK_JENKINS_USER,
-        //     basicAuthPassword: process.env.MOZAIK_JENKINS_PASSWORD
-        // }
+        jenkins: {
+            baseUrl: process.env.MOZAIK_JENKINS_URL,
+            basicAuthUser: process.env.MOZAIK_JENKINS_USER,
+            basicAuthPassword: process.env.MOZAIK_JENKINS_PASSWORD
+        }
     },
 
     // define duration between each dashboard rotation (ms)

--- a/coverage/post_badges.py
+++ b/coverage/post_badges.py
@@ -1,0 +1,99 @@
+# script to post badge markup to s3 using coveralls API and build page
+# this requires a python2.7 environment that includes:
+# - requests
+# - boto
+# - beautifulsoup4
+# - S3_KEY and S3_SECRET credentials variables
+from __future__ import print_function
+import sys
+import os
+import datetime
+
+import requests
+import boto
+from boto.s3.key import Key
+from boto.s3.connection import OrdinaryCallingFormat
+from bs4 import BeautifulSoup as bs
+
+TEMPLATE = """
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>cfgov-refresh coverage badges</title>
+    <style>
+    table {{
+      font-size:1.9em; font-family: Montserrat, sans-serif; width:100%;
+    }}
+    img {{
+      width:105%; height:105%; display:block;
+    }}
+    img.status {{ width:48%; height:48%; }}
+    td {{ width:50%; }}
+    </style>
+</head>
+<body>
+<div>
+<img class="status" src="https://travis-ci.org/cfpb/cfgov-refresh.svg?branch=master" alt="build status"/>
+<hr>
+<table>
+<tr>
+<td>All code</td><td><img src="{}" alt="overall coverage"></td></tr>
+<tr>
+<td>JS</td><td><img src="{}" alt="javascript coverage"></td></tr>
+<tr>
+<td> Python</td><td><img src="{}" alt="python coverage"></td></tr>
+</table>
+</div>
+</body>
+</html>
+"""
+
+S3_KEY = os.getenv('S3_KEY', '')
+S3_SECRET = os.getenv('S3_SECRET', '')
+S3_BASE = 'files.consumerfinance.gov'
+COVERALLS = 'https://coveralls.io'
+CFGOV_BASE = '{}/github/cfpb/cfgov-refresh'.format(COVERALLS)
+BADGES = {
+    'overall': '',
+    'js': '',
+    'python': ''
+}
+BADGE_URL = (
+    'https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_{}.svg'
+    )
+
+
+def get_badges():
+    initial_data = requests.get('{}.json'.format(CFGOV_BASE)).json()
+    BADGES['overall'] = initial_data['badge_url']
+    commit_sha = initial_data['commit_sha']
+    build_soup = bs(requests.get('{}/builds/{}'.format(COVERALLS,
+                                                       commit_sha)).text,
+                                                       'html.parser')
+    results_div = build_soup.find(True, {'class': ['show-item',
+                                         'show-last-build-detail']})
+    rows = results_div.findAll('tr')[1:]
+    for row in rows:
+        coverage = row.find('div').find('div').text
+        if 'frontend' in row.find('a').text:
+            BADGES['js'] = BADGE_URL.format(int(round(float(coverage), 2)))
+        elif 'backend' in row.find('a').text:
+            BADGES['python'] = BADGE_URL.format(int(round(float(coverage), 2)))
+    with open('badges.html', 'w') as f:
+        content = TEMPLATE.format(BADGES['overall'],
+                                  BADGES['js'],
+                                  BADGES['python']).encode('utf-8')
+        f.write(content)
+    s3 = boto.connect_s3(S3_KEY, S3_SECRET,
+                         calling_format=OrdinaryCallingFormat())
+    bucket = s3.get_bucket(S3_BASE)
+    prep = Key(bucket=bucket, name='build/badges/badges.html')
+    prep.content_type = 'text/plain'
+    prep.set_contents_from_filename('badges.html')
+    print('badges updated {}'.format(datetime.datetime.now()))
+
+if __name__ == "__main__":
+    print('{} reporting for duty: {}'.format(sys.argv[0],
+                                             datetime.datetime.now()))
+    get_badges()

--- a/coverage/post_badges.py
+++ b/coverage/post_badges.py
@@ -23,12 +23,12 @@ TEMPLATE = """
     <title>cfgov-refresh coverage badges</title>
     <style>
     table {{
-      font-size:1.9em; font-family: Montserrat, sans-serif; width:100%;
+      font-size:1.5em; font-family: Montserrat, sans-serif; width:100%;
     }}
     img {{
       width:105%; height:105%; display:block;
     }}
-    img.status {{ width:48%; height:48%; }}
+    img.status {{ width:47%; height:47%; }}
     td {{ width:50%; }}
     </style>
 </head>

--- a/coverage/requirements.txt
+++ b/coverage/requirements.txt
@@ -1,0 +1,3 @@
+requests==2.11.1
+beautifulsoup4==4.5.1
+boto==2.42.0


### PR DESCRIPTION
This includes a Python script that can be run from Jenkins (or elsewhere)
to update our badges with figures for JS, Python and overall coverage.
If we get our travis repo properly reset, we may be able to do without
this script, or to simplify it.
## Additions
- post_badges.py
## Changes
- config for Code Coverage widget
## Review
- @contolini @sebworks 
## Screenshots

New widget looks something like this:

<img width="346" alt="badges1003" src="https://cloud.githubusercontent.com/assets/515885/19058284/fa7d3f1a-89a3-11e6-901d-e3d8895ecf30.png">
